### PR TITLE
fix(deps): Use jshint as a peerDependency instead of a hard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,16 @@
     "MIT"
   ],
   "dependencies": {
-    "jshint": "~2.8.0",
     "rcloader": "^0.1.4"
   },
   "peerDependencies": {
-    "karma": ">=0.9"
+    "karma": ">=0.9",
+    "jshint": "^2.8.0"
   },
   "devDependencies": {
+    "karma": ">=0.9",
     "chai": "^3.3.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "jshint": "^2.8.0"
   }
 }


### PR DESCRIPTION
Upgrades jshint to latest and marks it as a peerDependency for better interoperability with other modules depending on jshint. 
